### PR TITLE
Do not push tags automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     * [`autobump`](#autobump)
     * [`release`](#release)
     * [`tag`](#tag)
+    * [`tagAndPush`](#tagandpush)
     * [`printVersion`](#printversion)
   * [Options and use-cases](#options-and-use-cases)
     * [General options](#general-options)
@@ -129,7 +130,11 @@ This task specifies that the build is a release build, which means that a snapsh
 
 ## `tag`
 
-This task with create a tag corresponding to the current version (with an optional prefix; see `tagPrefix` under **General options**) *and* push all tags. It is recommended to use this tag along with the `release` task when creating a release. **You cannot tag a snapshot release; use pre-release identifiers instead**.
+This task will create a tag corresponding to the current version (with an optional prefix; see `tagPrefix` under **General options**). It is recommended to use this task along with the `release` task when creating a release. **You cannot tag a snapshot release; use pre-release identifiers instead**.
+
+## `tagAndPush`
+
+This task will create a tag corresponding to the current version (with an optional prefix; see `tagPrefix` under **General options**) *and* push the created tag. It is recommended to use this task along with the `release` task when creating a release. **You cannot tag a snapshot release; use pre-release identifiers instead**.
 
 ## `printVersion`
 

--- a/src/main/groovy/net/vivin/gradle/versioning/SemanticBuildVersioningPlugin.groovy
+++ b/src/main/groovy/net/vivin/gradle/versioning/SemanticBuildVersioningPlugin.groovy
@@ -123,6 +123,10 @@ class SemanticBuildVersioningPlugin implements Plugin<Project> {
         project.task('tag', type: TagTask, group: "versioning") {
             semanticBuildVersion = version
         }
+        project.task('tagAndPush', type: TagTask, group: "versioning") {
+            push true
+            semanticBuildVersion = version
+        }
 
         project.task('printVersion') << {
             println project.version

--- a/src/main/groovy/net/vivin/gradle/versioning/tasks/TagTask.groovy
+++ b/src/main/groovy/net/vivin/gradle/versioning/tasks/TagTask.groovy
@@ -13,7 +13,7 @@ import org.gradle.tooling.BuildException
  * @author vivin
  */
 class TagTask extends DefaultTask {
-
+    boolean push
     SemanticBuildVersion semanticBuildVersion
 
     @TaskAction
@@ -35,7 +35,9 @@ class TagTask extends DefaultTask {
         }
 
         Git git = new Git(repository)
-        git.tag().setName(tag).call()
-        git.push().setPushTags().call()
+        def tagRef = git.tag().setName(tag).call()
+        if (push) {
+            git.push().add(tagRef).call()
+        }
     }
 }


### PR DESCRIPTION
Currently there is no way to not push tags.
Even worse, as far as I understand the docs, not only the created tag is pushed, but **all** tags.
I usually have many tags locally that I never want anyone to see, so IF something is pushed, it should only be the tag just created.

But I personally don't even want the automatic pushing. I e. g. often clone some project, make some changes and create an own version with some suffix that I then use further on. In this case I don't even have the right to push, besides not wanting to push that anyway. And even if I work on an own project I might not want to automatically push tags but do that manually.

There are people that use your plugin manually and not just from some CI server. ;-)
