### PR TITLE
Do not insert a dash between tagPrefix and version

### DIFF
--- a/src/main/groovy/net/vivin/gradle/versioning/tasks/TagTask.groovy
+++ b/src/main/groovy/net/vivin/gradle/versioning/tasks/TagTask.groovy
@@ -29,10 +29,7 @@ class TagTask extends DefaultTask {
             .findGitDir(new File(project.getRootProject().projectDir.absolutePath))
             .build()
 
-        String tag = semanticBuildVersion.toString()
-        if(!semanticBuildVersion.tagPrefix.isEmpty()) {
-            tag = String.format("%s-%s", semanticBuildVersion.tagPrefix, tag)
-        }
+        String tag = String.format("%s%s", semanticBuildVersion.tagPrefix, semanticBuildVersion.toString())
 
         Git git = new Git(repository)
         git.tag().setName(tag).call()

--- a/src/test/groovy/net/vivin/gradle/versioning/TagTaskTests.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/TagTaskTests.groovy
@@ -75,12 +75,29 @@ class TagTaskTests extends TestNGRepositoryTestCase {
             .commit()
 
         SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
-        version.tagPrefix = "prefix"
+        version.tagPrefix = "prefix-"
         release(version)
 
         project.tasks.tag.tag()
 
         version.versionUtils.refresh()
         assertEquals(testRepository.getHeadTag(), "prefix-0.0.2")
+    }
+
+    @Test
+    void testTagIsCreatedWithDashlessPrefix() {
+        testRepository
+            .commitAndTag("v0.0.1")
+            .makeChanges()
+            .commit()
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.tagPrefix = "v"
+        release(version)
+
+        project.tasks.tag.tag()
+
+        version.versionUtils.refresh()
+        assertEquals(testRepository.getHeadTag(), "v0.0.2")
     }
 }


### PR DESCRIPTION
It is an often seen pattern to tag versions in VCS as `v1.2.3`. This is currently not possible with your plugin as setting `tagPrefix` to `v` ends in the tag `v-1.2.3`. If someone wants to have a dash in there, he can add it to the `tagPrefix` like in `myproject-` to get `myproject-1.2.3`. So please remove the automatically added dash.
