### PR TITLE
IncorrectObjectTypeException

### DIFF
--- a/src/main/groovy/net/vivin/gradle/versioning/tasks/TagTask.groovy
+++ b/src/main/groovy/net/vivin/gradle/versioning/tasks/TagTask.groovy
@@ -32,7 +32,7 @@ class TagTask extends DefaultTask {
         String tag = String.format("%s%s", semanticBuildVersion.tagPrefix, semanticBuildVersion.toString())
 
         Git git = new Git(repository)
-        def tagRef = git.tag().setName(tag).call()
+        def tagRef = git.tag().setAnnotated(false).setName(tag).call()
         if (push) {
             git.push().add(tagRef).call()
         }

--- a/src/test/groovy/net/vivin/gradle/versioning/TestRepository.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/TestRepository.groovy
@@ -20,7 +20,7 @@ class TestRepository {
             .call()
 
         git.tag()
-            .setAnnotated(true)
+            .setAnnotated(false)
             .setName(tag)
             .call()
 


### PR DESCRIPTION
I tried to apply the plugin to a project and when I execute any task (not necessarily one from this plugin) I suddenly get the following exception.

```
Caused by: org.gradle.tooling.BuildException: Unexpected error while retrieving tag information: Object da74c19f1a9bc797d1b54bebc86a4c1dfddeeff3 is not a tag.
        at net.vivin.gradle.versioning.VersionUtils.parseTag(VersionUtils.java:310)
        at net.vivin.gradle.versioning.VersionUtils.lambda$retrieveTagInformation$1(VersionUtils.java:225)
        at net.vivin.gradle.versioning.VersionUtils.retrieveTagInformation(VersionUtils.java:229)
        at net.vivin.gradle.versioning.VersionUtils.refresh(VersionUtils.java:43)
        at net.vivin.gradle.versioning.VersionUtils$refresh.call(Unknown Source)
        at net.vivin.gradle.versioning.SemanticBuildVersion.toString(SemanticBuildVersion.groovy:122)
        at org.gradle.api.internal.artifacts.ProjectBackedModule.getVersion(ProjectBackedModule.java:38)
        at org.gradle.api.publish.maven.plugins.MavenPublishPlugin$MavenPublicationFactory.create(MavenPublishPlugin.java:175)
        at org.gradle.api.publish.maven.plugins.MavenPublishPlugin$MavenPublicationFactory.create(MavenPublishPlugin.java:161)
        at org.gradle.api.internal.DefaultPolymorphicNamedEntityInstantiator.create(DefaultPolymorphicNamedEntityInstantiator.java:52)
        at org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer.doCreate(DefaultPolymorphicDomainObjectContainer.java:59)
        at org.gradle.api.internal.AbstractPolymorphicDomainObjectContainer.create(AbstractPolymorphicDomainObjectContainer.java:63)
        at org.gradle.api.internal.PolymorphicDomainObjectContainerConfigureDelegate._configure(PolymorphicDomainObjectContainerConfigureDelegate.java:45)
        at org.gradle.internal.metaobject.ConfigureDelegate.invokeMethod(ConfigureDelegate.java:68)
        at build_13pn1tt1ssqivnf0gb1fjk4cc$_run_closure6$_closure7.doCall(D:\Sourcecode\other\FritzTR064\build.gradle:39)
        at org.gradle.api.internal.ClosureBackedAction.execute(ClosureBackedAction.java:70)
        at org.gradle.util.ConfigureUtil.configureTarget(ConfigureUtil.java:160)
        at org.gradle.util.ConfigureUtil.configureSelf(ConfigureUtil.java:148)
        at org.gradle.api.internal.AbstractNamedDomainObjectContainer.configure(AbstractNamedDomainObjectContainer.java:74)
        at org.gradle.api.internal.AbstractNamedDomainObjectContainer.configure(AbstractNamedDomainObjectContainer.java:29)
        at org.gradle.util.ConfigureUtil.configure(ConfigureUtil.java:104)
        at org.gradle.util.ConfigureUtil$1.execute(ConfigureUtil.java:123)
        at org.gradle.api.publish.internal.DefaultPublishingExtension.publications(DefaultPublishingExtension.java:48)
        at org.gradle.api.publish.internal.DefaultPublishingExtension_Decorated.publications(Unknown Source)
        at org.gradle.internal.metaobject.BeanDynamicObject$MetaClassAdapter.invokeMethod(BeanDynamicObject.java:382)
        at org.gradle.internal.metaobject.BeanDynamicObject.invokeMethod(BeanDynamicObject.java:170)
        at org.gradle.internal.metaobject.CompositeDynamicObject.invokeMethod(CompositeDynamicObject.java:96)
        at org.gradle.internal.metaobject.MixInClosurePropertiesAsMethodsDynamicObject.invokeMethod(MixInClosurePropertiesAsMethodsDynamicObject.java:30)
        at org.gradle.internal.metaobject.ConfigureDelegate.invokeMethod(ConfigureDelegate.java:59)
        at build_13pn1tt1ssqivnf0gb1fjk4cc$_run_closure6.doCall(D:\Sourcecode\other\FritzTR064\build.gradle:38)
        at org.gradle.api.internal.ClosureBackedAction.execute(ClosureBackedAction.java:70)
        at org.gradle.util.ConfigureUtil.configureTarget(ConfigureUtil.java:160)
        at org.gradle.util.ConfigureUtil.configure(ConfigureUtil.java:106)
        at org.gradle.util.ConfigureUtil$1.execute(ConfigureUtil.java:123)
        at org.gradle.listener.ActionBroadcast.execute(ActionBroadcast.java:39)
        at org.gradle.api.internal.plugins.ExtensionsStorage$DeferredConfigurableExtensionHolder.configureNow(ExtensionsStorage.java:183)
        at org.gradle.api.internal.plugins.ExtensionsStorage$DeferredConfigurableExtensionHolder.get(ExtensionsStorage.java:162)
        at org.gradle.api.internal.plugins.ExtensionsStorage.getByType(ExtensionsStorage.java:77)
        at org.gradle.api.internal.plugins.DefaultConvention.getByType(DefaultConvention.java:113)
        at org.gradle.api.publish.plugins.PublishingPlugin$Rules.publishing(PublishingPlugin.java:79)
        at org.gradle.model.internal.method.WeaklyTypeReferencingMethod.invoke(WeaklyTypeReferencingMethod.java:100)
        at org.gradle.model.internal.inspect.DefaultModelRuleInvoker.invoke(DefaultModelRuleInvoker.java:36)
        at org.gradle.model.internal.inspect.UnmanagedModelCreationRuleExtractor$UnmanagedElementCreationAction.execute(UnmanagedModelCreationRuleExtractor.java:77)
        at org.gradle.model.internal.inspect.ModelRuleExtractor$DefaultExtractedRuleSource$ContextualizedModelAction.execute(ModelRuleExtractor.java:515)
        at org.gradle.model.internal.registry.DefaultModelRegistry$4.run(DefaultModelRegistry.java:455)
        at org.gradle.model.internal.registry.RuleContext.run(RuleContext.java:42)
        at org.gradle.model.internal.registry.DefaultModelRegistry.fireAction(DefaultModelRegistry.java:452)
        ... 73 more
Caused by: org.eclipse.jgit.errors.IncorrectObjectTypeException: Object da74c19f1a9bc797d1b54bebc86a4c1dfddeeff3 is not a tag.
        at org.eclipse.jgit.revwalk.RevWalk.parseTag(RevWalk.java:834)
        at net.vivin.gradle.versioning.VersionUtils.parseTag(VersionUtils.java:308)
        ... 119 more
```
