### PR TITLE
set a default tagPattern that only finds tags that contain a semantic version part

### DIFF
--- a/src/main/groovy/net/vivin/gradle/versioning/SemanticBuildVersion.groovy
+++ b/src/main/groovy/net/vivin/gradle/versioning/SemanticBuildVersion.groovy
@@ -19,7 +19,7 @@ class SemanticBuildVersion {
 
     String snapshotSuffix = "SNAPSHOT"
 
-    Pattern tagPattern = ~/.*/
+    Pattern tagPattern = ~/\d++\.\d++\.\d++/
 
     VersionsMatching versionsMatching = new VersionsMatching()
     PreRelease preReleaseConfiguration = null

--- a/src/test/groovy/net/vivin/gradle/versioning/TagTaskTests.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/TagTaskTests.groovy
@@ -140,4 +140,20 @@ class TagTaskTests extends TestNGRepositoryTestCase {
         assertFalse(originTags.contains("0.0.1"), "Origin repository contains tag '0.0.1'")
         assertTrue(originTags.contains("0.0.2"), "Origin repository contains tag '0.0.2'")
     }
+
+    @Test
+    void testNonVersionTagsDoesNotCauseBuildToFail() {
+        testRepository
+            .commitAndTag("3.1.2")
+            .commitAndTag("foo")
+            .makeChanges()
+            .commit()
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        release(version)
+
+        project.tasks.tag.tag()
+
+        version.versionUtils.refresh()
+    }
 }


### PR DESCRIPTION
If you have any non-version tag like `foo`, `bad`, `good` or similar, the build will break with an `ArrayIndexOutOfBoundsException` in `VersionUtils.compareVersions` when trying to access the second part of the version.
This patch sets up the semantic-version base appearance of three dot-separated numbers as default tag pattern so that other tags are not found.
