### PR TITLE
fix handling of multiple tags on the HEAD commit

### DIFF
--- a/src/test/groovy/net/vivin/gradle/versioning/MajorMinorPatchBumpingTests.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/MajorMinorPatchBumpingTests.groovy
@@ -81,6 +81,18 @@ class MajorMinorPatchBumpingTests extends TestNGRepositoryTestCase {
     }
 
     @Test
+    void testCheckingOutTagProducesSameVersionAsTagEvenIfOtherTagsArePresent() {
+        testRepository
+            .commitAndTag("3.1.2")
+            .commitAndTag("3.1.3")
+            .commitAndTag("3.1.4")
+            .checkout("3.1.2")
+            .tag("foo")
+
+        assertEquals(project.version.toString(), "3.1.2")
+    }
+
+    @Test
     void testBumpingPatchVersionForSnapshot() {
         testRepository
             .commitAndTag("0.0.2")

--- a/src/test/groovy/net/vivin/gradle/versioning/TestRepository.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/TestRepository.groovy
@@ -27,6 +27,16 @@ class TestRepository {
         return this
     }
 
+    TestRepository tag(String tag) {
+        Git git = new Git(repository)
+        git.tag()
+            .setAnnotated(false)
+            .setName(tag)
+            .call()
+
+        return this
+    }
+
     TestRepository commit() {
         Git git = new Git(repository)
         git.commit()


### PR DESCRIPTION
This PR should be applied after PRs #14 and #15, as without those the test is broken in other ways than relevant for this fix.
Using describe is porcelain and just gives you the nearest tag, but it is not defined what is delivered if you have multiple tags pointing on an object.
Thus it is better to list all tags that point to some object and then take on of those that are in the list of tags matching the settings.
As it is very unlikely that multiple sem-ver tags point to the same revision usually, anyone of those tags is returned.
