### PR TITLE
properly fail if a non-sem-ver tag was matched by tag matching

### DIFF
--- a/src/main/java/net/vivin/gradle/versioning/VersionUtils.java
+++ b/src/main/java/net/vivin/gradle/versioning/VersionUtils.java
@@ -2,11 +2,7 @@ package net.vivin.gradle.versioning;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.revwalk.RevTag;
-import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.gradle.tooling.BuildException;
 
@@ -254,6 +250,14 @@ public class VersionUtils {
     private int compareVersions(String a, String b) {
         String[] aVersionComponents = a.replaceAll("^(\\d+\\.\\d+\\.\\d+).*$", "$1").split("\\.");
         String[] bVersionComponents = b.replaceAll("^(\\d+\\.\\d+\\.\\d+).*$", "$1").split("\\.");
+
+        if ((aVersionComponents.length < 3)) {
+            throw new BuildException(String.format("The version '%s' does not contain a semantic versioning part, please check your tag matching settings", a), null);
+        }
+
+        if ((bVersionComponents.length < 3)) {
+            throw new BuildException(String.format("The version '%s' does not contain a semantic versioning part, please check your tag matching settings", b), null);
+        }
 
         int aNumericValue = 0;
         int bNumericValue = 0;

--- a/src/test/groovy/net/vivin/gradle/versioning/VersionUtilsTests.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/VersionUtilsTests.groovy
@@ -1,17 +1,31 @@
 package net.vivin.gradle.versioning
 
+import org.gradle.tooling.BuildException
 import org.testng.annotations.Test
 
 import static org.testng.Assert.assertFalse
 
 class VersionUtilsTests extends TestNGRepositoryTestCase {
+    @Test(expectedExceptions = BuildException,
+          expectedExceptionsMessageRegExp = /The version '0\.1' does not contain a semantic versioning part, please check your tag matching settings/)
+    void testNonSemVerTagsFailTheBuildWithAProperMessage() {
+        testRepository.commitAndTag('0.0.1')
+            .makeChanges()
+            .commitAndTag('0.1')
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.tagPattern = ~/.*/
+
+        version.versionUtils.determineVersion()
+    }
+
     @Test
     void testTaggedVersionIsRecognizedAsNonSnapshot() {
-        testRepository.commitAndTag("0.0.1")
+        testRepository.commitAndTag('0.0.1')
 
         SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
 
         version.versionUtils.determineVersion()
-        assertFalse(version.snapshot, "Tagged version should not be snapshot version")
+        assertFalse(version.snapshot, 'Tagged version should not be snapshot version')
     }
 }


### PR DESCRIPTION
Before you got an `ArrayIndexOutOfBoundsException` when trying to access the version parts as there were too few parts
