### PR TITLE
issue #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,11 @@ This task specifies that the build is a release build, which means that a snapsh
 
 ## `tag`
 
-This task will create a tag corresponding to the latest version (with an optional prefix; see `tagPrefix` under **General options**). It is recommended to use this task along with the `release` task when creating a release. **You cannot tag a snapshot release; use pre-release identifiers instead**.
+This task will create a tag corresponding to the latest version (with an optional prefix; see `tagPrefix` under **General options**). It is recommended to use this task along with the `release` task when creating a release. **You cannot tag a snapshot release; use pre-release identifiers instead**. Also note that you can use `tag` or `tagAndPush`, but not both at the same time.
 
 ## `tagAndPush`
 
-This task will create a tag corresponding to the latest version (with an optional prefix; see `tagPrefix` under **General options**) *and* push the created tag. It is recommended to use this task along with the `release` task when creating a release. **You cannot tag a snapshot release; use pre-release identifiers instead**.
+This task will create a tag corresponding to the latest version (with an optional prefix; see `tagPrefix` under **General options**) *and* push the created tag. It is recommended to use this task along with the `release` task when creating a release. **You cannot tag a snapshot release; use pre-release identifiers instead**. Also note that you can `tagAndPush` or `tag`, but not both at the same time.
 
 ## `printVersion`
 

--- a/src/main/groovy/net/vivin/gradle/versioning/SemanticBuildVersioningPlugin.groovy
+++ b/src/main/groovy/net/vivin/gradle/versioning/SemanticBuildVersioningPlugin.groovy
@@ -99,6 +99,10 @@ class SemanticBuildVersioningPlugin implements Plugin<Project> {
                 version.autobump = true
             }
 
+            if(it.hasTask(project.tasks.tag) && it.hasTask(project.tasks.tagAndPush)) {
+                throw new BuildException("Only one of tag or tagAndPush can be used at the same time", null)
+            }
+
             version.bump = bump
         }
 
@@ -133,6 +137,7 @@ class SemanticBuildVersioningPlugin implements Plugin<Project> {
 
             project.tasks.getByName('release').mustRunAfter('promoteToRelease').mustRunAfter(project.tasks.withType(BumpTask))
             project.tasks.getByName('tag').mustRunAfter('promoteToRelease').mustRunAfter(project.tasks.withType(BumpTask))
+            project.tasks.getByName('tagAndPush').mustRunAfter('promoteToRelease').mustRunAfter(project.tasks.withType(BumpTask))
         }
     }
 }

--- a/src/test/groovy/net/vivin/gradle/versioning/SemanticBuildVersionTest.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/SemanticBuildVersionTest.groovy
@@ -534,6 +534,12 @@ class SemanticBuildVersionTest extends TestNGRepositoryTestCase {
     }
 
     @Test
+    void testTagAndTagAndPushCausesBuildToFail() {
+        def buildResult = gradleRunner.withArguments('tag', 'tagAndPush').buildAndFail()
+        assertTrue(buildResult.output.contains('Only one of tag or tagAndPush can be used at the same time'), 'Build output contains correct error message')
+    }
+
+    @Test
     void testOnlyReleaseTaskDoesNotFail() {
         gradleRunner.withArguments('release').build()
     }
@@ -576,6 +582,12 @@ class SemanticBuildVersionTest extends TestNGRepositoryTestCase {
     @Test
     void testTagWithoutReleaseCausesBuildToFail() {
         def buildResult = gradleRunner.withArguments('tag').buildAndFail()
+        assertTrue(buildResult.output.contains('Cannot create a tag for a snapshot version'), 'Build output contains correct error message')
+    }
+
+    @Test
+    void testTagAndPushWithoutReleaseCausesBuildToFail() {
+        def buildResult = gradleRunner.withArguments('tagAndPush').buildAndFail()
         assertTrue(buildResult.output.contains('Cannot create a tag for a snapshot version'), 'Build output contains correct error message')
     }
 


### PR DESCRIPTION
Changes:
- Set mustRunAfter for tagAndPush similar to tag.
- Build fails now if tag and tagAndPush are used at the same time.
- Added tests.
- Updated README
