### PR TITLE
issue #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The plugin provides tasks that can be used to bump components of the version, or
  1. Only one version-component can be explicitly bumped at a time. This means that only one of `bumpMajor`, `bumpMinor`, `bumpPatch`, or `bumpPreRelease` can be used at a time.
  2. It is not possible to use `autobump` or `promoteToRelease` when explicitly bumping a version-component.
  3. With the exception of `bumpPreRelease`, all other version-component bumping-tasks can be used in conjunction with `newPreRelease`; this has the effect of bumping a version-component and adding a pre-release identifier at the same time to create a new pre-release version.
+ 4. It is not possible to modify the version in any manner if `HEAD` is already pointing to a tag that identifies a particular version. This is because it would then be possible to push out an identical artifact with a different version-number and violate semantic-versioning rules. For example, assuming that the latest version is `1.0.2`, it would be possible to check out tag `1.0.0`, bump the major version, and release it as `2.0.0`. For more information about tagging and checking out a tag, see `tag` and `tagAndPush`, and **Checking out a tag**.
 
 ## `bumpMajor`
 
@@ -299,5 +300,5 @@ project.version.with {
 
 ## Checking out a tag
 
-It is useful to check out a tag when you want to create a build of an older version. If you do this, the plugin will detect that `HEAD` is pointing to a tag and will use the corresponding version as the version of the build. **For this to work as expected, the tag you are checking out must not be excluded by `tagPattern`, `versionsMatching`, or `preRelease.pattern`**.
+It is useful to check out a tag when you want to create a build of an older version. If you do this, the plugin will detect that `HEAD` is pointing to a tag and will use the corresponding version as the version of the build. **It is not possible to bump or modify the version in any other manner if you have checked out a tag corresponding to that version**. **Also, for this to work as expected, the tag you are checking out must not be excluded by `tagPattern`, `versionsMatching`, or `preRelease.pattern`**.
 

--- a/src/main/java/net/vivin/gradle/versioning/VersionUtils.java
+++ b/src/main/java/net/vivin/gradle/versioning/VersionUtils.java
@@ -106,6 +106,10 @@ public class VersionUtils {
 
                 return versionFromTags;
             } else {
+                if(version.getBump() != null || version.isNewPreRelease() || version.isPromoteToRelease()) {
+                    throw new BuildException("Cannot bump the version, create a new pre-release version, or promote a pre-release version because HEAD is currently pointing to a tag that identifies an existing version. To be able to create a new version, you must make changes", null);
+                }
+
                 version.setSnapshot(false);
                 return headTag.replaceFirst("^.*?(\\d+\\.\\d+\\.\\d+-?)", "$1");
             }

--- a/src/test/groovy/net/vivin/gradle/versioning/MajorMinorPatchBumpingTests.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/MajorMinorPatchBumpingTests.groovy
@@ -514,4 +514,82 @@ class MajorMinorPatchBumpingTests extends TestNGRepositoryTestCase {
 
         assertEquals(project.version.toString(), "1.0.0")
     }
+
+    @Test(expectedExceptions = BuildException)
+    void testBumpingPatchVersionWhenHeadIsPointingToTagCausesBuildToFail() {
+        testRepository
+            .commitAndTag("1.0.0")
+            .commitAndTag("1.0.1")
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.bump = VersionComponent.PATCH
+        release(version)
+
+        project.version.toString()
+    }
+
+    @Test(expectedExceptions = BuildException)
+    void testBumpingMinorVersionWhenHeadIsPointingToTagCausesBuildToFail() {
+        testRepository
+            .commitAndTag("1.0.0")
+            .commitAndTag("1.0.1")
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.bump = VersionComponent.MINOR
+        release(version)
+
+        project.version.toString()
+    }
+
+    @Test(expectedExceptions = BuildException)
+    void testBumpingMajorVersionWhenHeadIsPointingToTagCausesBuildToFail() {
+        testRepository
+            .commitAndTag("1.0.0")
+            .commitAndTag("1.0.1")
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.bump = VersionComponent.MAJOR
+        release(version)
+
+        project.version.toString()
+    }
+
+    @Test(expectedExceptions = BuildException)
+    void testBumpingPatchVersionForSnapshotWhenHeadIsPointingToTagCausesBuildToFail() {
+        testRepository
+            .commitAndTag("1.0.0")
+            .commitAndTag("1.0.1")
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.bump = VersionComponent.PATCH
+        snapshot(version)
+
+        project.version.toString()
+    }
+
+    @Test(expectedExceptions = BuildException)
+    void testBumpingMinorVersionForSnapshotWhenHeadIsPointingToTagCausesBuildToFail() {
+        testRepository
+            .commitAndTag("1.0.0")
+            .commitAndTag("1.0.1")
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.bump = VersionComponent.MINOR
+        snapshot(version)
+
+        project.version.toString()
+    }
+
+    @Test(expectedExceptions = BuildException)
+    void testBumpingMajorVersionForSnapshotWhenHeadIsPointingToTagCausesBuildToFail() {
+        testRepository
+            .commitAndTag("1.0.0")
+            .commitAndTag("1.0.1")
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.bump = VersionComponent.MAJOR
+        snapshot(version)
+
+        project.version.toString()
+    }
 }

--- a/src/test/groovy/net/vivin/gradle/versioning/NewPreReleaseBumpingTests.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/NewPreReleaseBumpingTests.groovy
@@ -16,6 +16,44 @@ class NewPreReleaseBumpingTests extends TestNGRepositoryTestCase {
         project.version.toString()
     }
 
+    @Test(expectedExceptions = BuildException)
+    void testNewPreReleaseVersionWhenHeadIsPointingToTagCausesBuildToFail() {
+        testRepository
+            .commitAndTag("1.0.0")
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.preRelease {
+            startingVersion = "pre.0"
+            bump { String s ->
+                String[] parts = s.split("\\.")
+                return "${parts[0]}.${Integer.parseInt(parts[1]) + 1}"
+            }
+        }
+        release(version)
+        newPreRelease(version)
+
+        project.version.toString()
+    }
+
+    @Test(expectedExceptions = BuildException)
+    void testNewPreReleaseSnapshotVersionWhenHeadIsPointingToTagCausesBuildToFail() {
+        testRepository
+            .commitAndTag("1.0.0")
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.preRelease {
+            startingVersion = "pre.0"
+            bump { String s ->
+                String[] parts = s.split("\\.")
+                return "${parts[0]}.${Integer.parseInt(parts[1]) + 1}"
+            }
+        }
+        snapshot(version)
+        newPreRelease(version)
+
+        project.version.toString()
+    }
+
     @Test
     void testNewPreReleaseVersionWithoutPriorVersions() {
         SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()

--- a/src/test/groovy/net/vivin/gradle/versioning/PreReleaseBumpingTests.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/PreReleaseBumpingTests.groovy
@@ -84,6 +84,42 @@ class PreReleaseBumpingTests extends TestNGRepositoryTestCase {
         project.version.toString()
     }
 
+    @Test(expectedExceptions = BuildException)
+    void testBumpingPreReleaseVersionWhenHeadIsPointingToTagCausesBuildToFail() {
+        testRepository
+            .commitAndTag("0.2.0-alpha.0")
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.preRelease {
+            startingVersion = "alpha.0"
+            bump { String s ->
+                s
+            }
+        }
+        version.bump = VersionComponent.PRERELEASE
+        release(version)
+
+        project.version.toString()
+    }
+
+    @Test(expectedExceptions = BuildException)
+    void testBumpingPreReleaseSnapshotVersionWhenHeadIsPointingToTagCausesBuildToFail() {
+        testRepository
+            .commitAndTag("0.2.0-alpha.0")
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.preRelease {
+            startingVersion = "alpha.0"
+            bump { String s ->
+                s
+            }
+        }
+        version.bump = VersionComponent.PRERELEASE
+        snapshot(version)
+
+        project.version.toString()
+    }
+
     @Test
     void testBumpedPreReleaseVersionWithPriorPreReleaseVersionIsBumpedPreReleaseVersionForSnapshot() {
         testRepository
@@ -456,5 +492,41 @@ class PreReleaseBumpingTests extends TestNGRepositoryTestCase {
         promote(version)
 
         assertEquals(project.version.toString(), "0.2.1")
+    }
+
+    @Test(expectedExceptions = BuildException)
+    void testPromotingPreReleaseSnapshotVersionWhenHeadIsPointingToTagCausesBuildToFail() {
+        testRepository
+            .commitAndTag("0.2.0-alpha.0")
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.preRelease {
+            startingVersion = "alpha.0"
+            bump { String s ->
+                s
+            }
+        }
+        snapshot(version)
+        promote(version)
+
+        project.version.toString()
+    }
+
+    @Test(expectedExceptions = BuildException)
+    void testPromotingPreReleaseVersionWhenHeadIsPointingToTagCausesBuildToFail() {
+        testRepository
+            .commitAndTag("0.2.0-alpha.0")
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.preRelease {
+            startingVersion = "alpha.0"
+            bump { String s ->
+                s
+            }
+        }
+        release(version)
+        promote(version)
+
+        project.version.toString()
     }
 }


### PR DESCRIPTION
Changes:
- Build will now fail if an attempt is made to change the version in any way, when `HEAD` is pointing to a tag.
- Added tests for this case.
- Updated README with information regarding this situation.
