### PR TITLE
issue #27

### DIFF
--- a/src/main/java/net/vivin/gradle/versioning/VersionUtils.java
+++ b/src/main/java/net/vivin/gradle/versioning/VersionUtils.java
@@ -24,7 +24,7 @@ public class VersionUtils {
     private final Repository repository;
 
     private Set<String> tags = null;
-    private SortedSet<String> versions = null;
+    private SortedSet<String> versions = new TreeSet<>();
 
     public VersionUtils(SemanticBuildVersion version, String workingDirectory) {
         this.version = version;
@@ -64,7 +64,7 @@ public class VersionUtils {
             throw new BuildException("Cannot create a release version when there are uncommitted changes", null);
         }
 
-        if(versions == null) {
+        if(versions.isEmpty()) {
             String determinedVersion = version.getStartingVersion();
             if(version.isNewPreRelease()) {
 
@@ -142,7 +142,7 @@ public class VersionUtils {
             refresh();
         }
 
-        if(versions == null || versions.isEmpty()) {
+        if(versions.isEmpty()) {
             return null;
         } else {
             return versions.first();

--- a/src/test/groovy/net/vivin/gradle/versioning/VersionUtilsTests.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/VersionUtilsTests.groovy
@@ -4,6 +4,7 @@ import org.gradle.tooling.BuildException
 import org.testng.annotations.Test
 
 import static org.testng.Assert.assertFalse
+import static org.testng.Assert.assertNull
 
 class VersionUtilsTests extends TestNGRepositoryTestCase {
     @Test(expectedExceptions = BuildException,
@@ -27,5 +28,22 @@ class VersionUtilsTests extends TestNGRepositoryTestCase {
 
         version.versionUtils.determineVersion()
         assertFalse(version.snapshot, 'Tagged version should not be snapshot version')
+    }
+
+    @Test
+    void testLatestVersionWhenThereAreNoTagsIsNull() {
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+
+        assertNull(version.versionUtils.latestVersion, "Latest version should be null when there are no tags")
+    }
+
+    @Test
+    void testLatestVersionWhenThereAreNoMatchingTagsIsNull() {
+        testRepository.commitAndTag('foo-0.0.1')
+
+        SemanticBuildVersion version = (SemanticBuildVersion) project.getVersion()
+        version.tagPattern = ~/^bar/
+
+        assertNull(version.versionUtils.latestVersion, "Latest version should be null when there are no matching tags")
     }
 }


### PR DESCRIPTION
Changes:
- Initialize versions to an empty set so that we don't have to check whether it is null or empty (just check if it is empty).
- Added tests
