### PR TITLE
fix the circle ci build

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,8 +1,0 @@
-GRADLE_PROPERTIES="$HOME/.gradle/gradle.properties"
-
-if [ ! -f "$GRADLE_PROPERTIES" ]; then
-    touch $GRADLE_PROPERTIES
-    echo "gradle.publish.key=$PUBLISH_KEY" >> $GRADLE_PROPERTIES
-    echo "gradle.publish.secret=$PUBLISH_SECRET" >> $GRADLE_PROPERTIES
-fi
-

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import net.vivin.gradle.versioning.tasks.TagTask
 
 plugins {
-    // build scan plugin should be the first in the list to not  important information in the scans
+    // build scan plugin should be the first in the list to not loose important information in the scans
     id 'com.gradle.build-scan' version '1.5'
     id 'com.gradle.plugin-publish' version '0.9.4'
     id 'net.vivin.gradle-semantic-build-versioning' version '2.0.1'
@@ -31,6 +31,9 @@ repositories {
 }
 
 sourceCompatibility = 1.7
+
+project.ext.'gradle.publish.key' = System.env.PUBLISH_KEY
+project.ext.'gradle.publish.secret' = System.env.PUBLISH_SECRET
 
 sourceSets.main.java.srcDirs = []
 sourceSets.main.groovy.srcDir 'src/main/java'
@@ -90,6 +93,9 @@ if(project.hasProperty('disableGroovyOptimizations')) {
 }
 
 test {
+    if(System.env.CIRCLECI) {
+        maxHeapSize = '1G'
+    }
     jacoco.includes = ['net.vivin.gradle.versioning.*']
     finalizedBy jacocoTestReport
     doFirst {

--- a/circle.yml
+++ b/circle.yml
@@ -2,20 +2,18 @@ general:
   artifacts:
     - "build/reports/jacoco"
 
-dependencies:
-  pre:
-    - bin/setup.sh
-
 machine:
+  environment:
+    GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx1G
   java:
     version: oraclejdk8
 
 test:
   override:
-    - ./gradlew clean test -P disableGroovyOptimizations --stacktrace
+    - ./gradlew --info clean test -P disableGroovyOptimizations
 
 deployment:
   production:
     branch: master
     commands:
-      - ./gradlew autobump release publishPlugins tagAndPush -x test
+      - ./gradlew --info autobump release publishPlugins tagAndPush -x test


### PR DESCRIPTION
- Removing the setup.sh file and step is just a bit beautifying.
  Usually you can simply set a project property "foo" via environment variable by setting "ORG_GRADLE_PROJECT_foo" to the desired value. But unfortunately many shells including Bash and the CircleCI implementation have problems setting environment variables which contain dots.
  So I kept your PUBLISH_KEY and PUBLISH_SECRET environment variables, but simply set the correct project properties from the build script, instead of doing file manipulation.

- Regarding the failed builds, well, we were at a boundary of 4 GiB memory usage in multiple processes. There were the gradlew call, the Gradle Daemon that is now activated by default, a Gradle worker process and a Gradle test executor process. Those 4 processes together often touched the 4 GiB boundary which CircleCI enforces and then starts to kill processes. Gradles native monitoring of course cannot work, as there is plenty RAM and CPU available in the system, so it is also given to the JVM and Gradle does not see that it is reaching any boundary.

  To fix the situation I did the following steps:

  - I disabled the Gradle Daemon completely, which is recommended for CI systems anyway. It is ultimately useful for development machines to speed up work, but for the sake of reliable reproducible builds, it should always be off on CI systems. This is also recommended by the documentation.
  - I set the max memory for the gradlew process to 1 GiB
  - I set the max memory of the test executor process to 1 GiB if the build is running on CircleCI

  Before these changes, the build failed in 50% - 90%.
  With these changes I ran the build 30 times without a single failure.

  I'd really wonder if your change of setting the max memory to 2 GiB in the org.gradle.jvmargs would have had any effect.
  I don't think so, as this should only affect the Gradle Daemon process, which by default is restricted to 1 GiB, so you just allowed it to consume more memory, while it was not even the culprit.
  I guess it just accidentally worked and if you would start 30 builds, you would get quite some failing.

- I also removed the --stacktrace option and added the --info option instead
  --stacktrace is usually too noisy, e. g. you get a full stracktrace for each deprecation warning and also each build failure, even if the message is clear enough
  I would not enable this by default.
  But having --info level output in a CI build usually is more appropriate than lifecycle level, at least that is what the past has told me. :-)