### PR TITLE
Fix for issue #68

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,9 +61,9 @@ task createJacocoAgentClasspathFile {
 }
 
 dependencies {
-    compile 'org.eclipse.jgit:org.eclipse.jgit:4.4.0.201606070830-r'
+    compile 'org.eclipse.jgit:org.eclipse.jgit:4.6.0.201612231935-r'
 
-    testCompile 'org.eclipse.jgit:org.eclipse.jgit.junit:4.4.0.201606070830-r'
+    testCompile 'org.eclipse.jgit:org.eclipse.jgit.junit:4.6.0.201612231935-r'
     testCompile 'org.jmockit:jmockit:1.28'
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'


### PR DESCRIPTION
Upgrading to JGit 4.6.0. In some situations on OS X, JGit erroneously reports that there are uncommitted changes when there aren't. See [here](https://github.com/sbt/sbt-git/issues/92).