### PR TITLE
Fix for improper working directory

### DIFF
--- a/src/main/groovy/net/vivin/gradle/versioning/VersionUtils.groovy
+++ b/src/main/groovy/net/vivin/gradle/versioning/VersionUtils.groovy
@@ -36,10 +36,20 @@ class VersionUtils {
         this.version = version
 
         try {
-            this.repository = new FileRepositoryBuilder()
+            FileRepositoryBuilder builder = new FileRepositoryBuilder()
                 .setWorkTree(workingDirectory)
                 .findGitDir(workingDirectory)
-                .build()
+
+            if(!builder.gitDir) {
+                throw new BuildException("Unable to find Git repository", null)
+            }
+
+            if(builder.gitDir.parentFile.absolutePath != workingDirectory.absolutePath) {
+                builder.setWorkTree(builder.gitDir.parentFile)
+            }
+
+            repository = builder.build()
+
         } catch(IOException e) {
             throw new BuildException("Unable to find Git repository: ${e.message}", e)
         }

--- a/src/test/groovy/net/vivin/gradle/versioning/SemanticBuildVersionPluginSpecification.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/SemanticBuildVersionPluginSpecification.groovy
@@ -13,7 +13,7 @@ class SemanticBuildVersionPluginSpecification extends Specification {
     private GradleRunner gradleRunner
 
     @Unroll
-    def '\'#projectProperties.first()\' with \'#projectProperties.last()\' causes build to fail'(projectProperties, expectedFailureMessage, GradleRunner gradleRunner) {
+    def '\'#projectProperties.first()\' with \'#projectProperties.last()\' causes build to fail'(projectProperties, expectedFailureMessage) {
         when:
         def arguments = projectProperties.collectMany { ['-P', it] }
         def buildResult = gradleRunner.withArguments(arguments).buildAndFail()
@@ -29,9 +29,6 @@ class SemanticBuildVersionPluginSpecification extends Specification {
         ['promoteToRelease', 'bumpComponent=minor']       || 'Bumping any component while also promoting a pre-release is not supported'
         ['promoteToRelease', 'bumpComponent=patch']       || 'Bumping any component while also promoting a pre-release is not supported'
         ['promoteToRelease', 'bumpComponent=pre-release'] || 'Bumping any component while also promoting a pre-release is not supported'
-
-        and:
-        gradleRunner = null
     }
 
     @Unroll

--- a/src/test/groovy/net/vivin/gradle/versioning/TagTaskSpecification.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/TagTaskSpecification.groovy
@@ -59,7 +59,7 @@ class TagTaskSpecification extends Specification {
         def buildResult = gradleRunner.withArguments('-P', 'release', 'tag').buildAndFail()
 
         then:
-        buildResult.output.contains 'Tag on repository without HEAD currently not supported'
+        buildResult.output.contains 'Unable to find Git repository'
     }
 
     @Unroll('#testName')


### PR DESCRIPTION
When using this plugin in a multiproject, where sub projects are versioned separately, the workTree set for the repository is the current project's project directory. However, the git directory lives in the root project's directory. This causes strange issues such as seeing uncommitted changes when there are none.