### PR TITLE
update jgit dependency to 4.8.0.201706111038-r

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,9 @@ task createJacocoAgentClasspathFile {
 }
 
 dependencies {
-    compile 'org.eclipse.jgit:org.eclipse.jgit:4.5.0.201609210915-r'
+    compile 'org.eclipse.jgit:org.eclipse.jgit:4.8.0.201706111038-r'
 
-    testCompile 'org.eclipse.jgit:org.eclipse.jgit.junit:4.5.0.201609210915-r'
+    testCompile 'org.eclipse.jgit:org.eclipse.jgit.junit:4.8.0.201706111038-r'
     testCompile 'org.jmockit:jmockit:1.28'
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'


### PR DESCRIPTION
The previous version (4.5.0.201609210915-r) had false positives when testing for uncomitted changes in a git lfs repository. In the result the plugin prevented creating a release version.

see: #76 