### PR TITLE
allow promotion to release without code changes -- fixes #108

### DIFF
--- a/src/main/groovy/net/vivin/gradle/versioning/VersionUtils.groovy
+++ b/src/main/groovy/net/vivin/gradle/versioning/VersionUtils.groovy
@@ -109,7 +109,7 @@ class VersionUtils {
 
                 result = versionFromTags
             } else {
-                if(version.bump || version.newPreRelease || version.promoteToRelease) {
+                if(version.bump || version.newPreRelease) {
                     throw new BuildException('Cannot bump the version, create a new pre-release version, or promote a pre-release version because HEAD is currently pointing to a tag that identifies an existing version. To be able to create a new version, you must make changes', null)
                 }
 

--- a/src/test/groovy/net/vivin/gradle/versioning/VersionUtilsSpecification.groovy
+++ b/src/test/groovy/net/vivin/gradle/versioning/VersionUtilsSpecification.groovy
@@ -243,7 +243,11 @@ class VersionUtilsSpecification extends Specification {
             [[false, false, false, null, false],
              [false, false, false, null, true],
              [false, false, true, null, false],
-             [false, false, true, null, true]]).findAll {
+             [false, false, true, null, true],
+             [false, true, false, null, true],
+             [false, true, false, null, false],
+             [false, true, true, null, true],
+             [false, true, true, null, false]]).findAll {
             // exclude the 12 cases that fail due to another reason
             !(it[1] && (it[0] || it[3]))
         }


### PR DESCRIPTION
Proposed fix for #108. Needs review.

Note -- excluded 4 tests (which otherwise would now fail) from `VersionUtils` I think it is correct but should be verified as well! Also note that there were 480 failing tests _before this change_ which are still failing.

