### PR TITLE
Support printing latest version with 'printVersion' task

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     * [`newPreRelease`](#newprerelease)
     * [`promoteToRelease`](#promotetorelease)
     * [`release`](#release)
+    * [`current`](#current)
   * [Tasks](#tasks)
     * [`tag`](#tag)
       * [`message`](#message)
@@ -136,6 +137,11 @@ This property specifies that the build is a release build, which means that a sn
 1. It is not possible to use `promoteToRelease` when explicitly bumping a version-component.
 1. With the exception of `bumpComponent=pre-release`, all other version-component bumping-values can be used in conjunction with `newPreRelease`; this has the effect of bumping a version-component and adding a pre-release identifier at the same time to create a new pre-release version.
 1. It is not possible to modify the version in any manner if `HEAD` is at a commit that has been tagged to identify a particular version (and there are no uncommitted changes). This is because it would then be possible to push out an identical artifact with a different version-number and violate semantic-versioning rules. For example, assuming that the base version is `1.0.2`, it would be possible to check out tag `1.0.0`, bump the major version, and release it as `2.0.0`. For more information about tagging and checking out a tag, see [`tag`](#tag) and [Checking out a tag](#checking-out-a-tag).
+
+## `latest`
+
+This property will print the latest version (most recent existing tag) instead of the "calculated one",
+and is only applied when used with [`printVersion`](#printversion) task.
 
 # Tasks
 

--- a/src/main/groovy/net/vivin/gradle/versioning/SemanticBuildVersioningPlugin.groovy
+++ b/src/main/groovy/net/vivin/gradle/versioning/SemanticBuildVersioningPlugin.groovy
@@ -69,6 +69,9 @@ class SemanticBuildVersioningPlugin implements Plugin<Settings> {
             }
 
             project.task('printVersion').doLast {
+                if (project.hasProperty("latest")){
+                    project.version = semanticBuildVersion.versionUtils.latestVersion
+                }
                 logger.quiet project.version as String
             }
 


### PR DESCRIPTION
It would be useful to be able to print latest version and not only "next calculated one".
This PR adds support for that.

Please note that there are almost 700 tests failing that were there prior to this change, but the `MultiProjectSpecification` tests (including the newly added ones) seem to be passing fine.